### PR TITLE
Fix markdown links (custom format example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The default, url, will just have the url of the artifact in the comment.
 
 Name will result in `[name](url)`
 
-The final format is custom and is a format string e.g `Whatever ({name})[{url}] etc`
+The final format is custom and is a format string e.g `Whatever [{name}]({url}) etc`
 
 
 ## Related issues

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
   format:
     description: format to be applied to all
     required: false
-    default: url # set to name for (name)[url] or supply custom "Whatever ({name})[{url}] etc"
+    default: url # set to name for (name)[url] or supply custom "Whatever [{name}]({url}) etc"
   includesFormatted:
     description: instead of applying same format to all - array of objects {name:string,format?:string}
     required: false


### PR DESCRIPTION
[GitHub docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#links)